### PR TITLE
Bump logback to 1.2.12

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,5 +20,6 @@
              :c08 {:dependencies [[org.clojure/clojure  "1.8.0"]]}
              :c09 {:dependencies [[org.clojure/clojure  "1.9.0"]]}
              :c10 {:dependencies [[org.clojure/clojure  "1.10.1"]]}
+             :c11 {:dependencies [[org.clojure/clojure  "1.11.1"]]}
              :dln {:jvm-opts ["-Dclojure.compiler.direct-linking=true"]}}
-  :aliases {"test-all" ["with-profile" "c06,dev:c07,dev:c08,dev:c09,dev:c10,dev" "test"]})
+  :aliases {"test-all" ["with-profile" "c06,dev:c07,dev:c08,dev:c09,dev:c10,dev:c11,dev" "test"]})

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.codehaus.janino/janino     "3.1.2"]  ; for conditional config processing
-                 [ch.qos.logback/logback-classic "1.2.8"]
-                 [ch.qos.logback/logback-core    "1.2.8"]]
+                 [ch.qos.logback/logback-classic "1.2.12"]
+                 [ch.qos.logback/logback-core    "1.2.12"]]
   :java-source-paths ["java-src"]
   :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
   :global-vars {*warn-on-reflection* true


### PR DESCRIPTION
Updates logback-core and logback-classic to 1.2.12.

This resolves [CVE-2021-42550](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42550): even though the CVE description mentions "logback version 1.2.7 and prior", [logback's news page](https://logback.qos.ch/news.html#1.2.9) seems to indicate this wasn't fully fixed until 1.2.9. There's also a [GitHub advisory](https://github.com/advisories/GHSA-668q-qrv7-99fm) whose metadata seems to agree with this, although its description contains the same "version 1.2.7 and prior" verbiage.
